### PR TITLE
remove `--graph` flag from git log command

### DIFF
--- a/lua/telescope/_extensions/git_diffs.lua
+++ b/lua/telescope/_extensions/git_diffs.lua
@@ -20,9 +20,7 @@ local function diffview(prompt_bufnr)
     return
   end
 
-  local new = string.sub(selections[1].value, 1, 8)
-  local old = string.sub(selections[2].value, 1, 8)
-  vim.cmd(string.format("DiffviewOpen -uno %s %s", old, new))
+  vim.cmd(string.format("DiffviewOpen -uno %s %s", selections[1].value, selections[2].value))
 end
 
 local function diff_commits(opts)
@@ -30,7 +28,7 @@ local function diff_commits(opts)
   opts.entry_maker = vim.F.if_nil(opts.entry_maker, make_entry.gen_from_git_commits(opts))
 
 
-  local git_command = { "git", "log", "--oneline", "--graph", "--decorate", "--all", "." }
+  local git_command = { "git", "log", "--oneline", "--decorate", "--all", "." }
   pickers.new(opts, {
     prompt_title = opts.prompt_title or "git diff_commits",
     finder = finders.new_oneshot_job(git_command, opts),


### PR DESCRIPTION
when using `--graph` , selected substrings are  `*` and `|`  prefixes before short commit hashes. is there better way to keep using `--graph` and parse commit hashes properly?