### PR TITLE
Add ability to select one commit

### DIFF
--- a/lua/telescope/_extensions/git_diffs.lua
+++ b/lua/telescope/_extensions/git_diffs.lua
@@ -15,7 +15,7 @@ local function diffview(prompt_bufnr)
   actions.close(prompt_bufnr)
 
 
-  if #selections < 1 or #selections > 2 then
+  if #selections > 2 then
     utils.notify("diff_commits", { level = "WARN", msg = "must select 1 or 2 commits" })
     return
   end
@@ -27,13 +27,14 @@ local function diffview(prompt_bufnr)
            tonumber(vim.fn.systemlist("git show -s --format=%ct " .. b.value)[1])
   end)
 
-  local old = string.sub(selections[1].value, 1, 8)
+  local old = #selections == 0 and string.sub(action_state.get_selected_entry().ordinal, 1, 7) or
+                                   string.sub(selections[1].value, 1, 8)
 
-  if #selections == 1 then
-    vim.cmd(string.format("DiffviewOpen %s^!", old))
-  else
+  if #selections == 2 then
     local new = string.sub(selections[2].value, 1, 8)
     vim.cmd(string.format("DiffviewOpen %s..%s", old, new))
+  else
+    vim.cmd(string.format("DiffviewOpen %s^!", old))
   end
 
   vim.cmd([[stopinsert]])

--- a/lua/telescope/_extensions/git_diffs.lua
+++ b/lua/telescope/_extensions/git_diffs.lua
@@ -15,15 +15,22 @@ local function diffview(prompt_bufnr)
   actions.close(prompt_bufnr)
 
 
-  if #selections ~= 2 then
-    utils.notify("diff_commits", { level = "WARN", msg = "must select 2 commits" })
+  if #selections < 1 or #selections > 2 then
+    utils.notify("diff_commits", { level = "WARN", msg = "must select 1 or 2 commits" })
     return
   end
 
 
-  local new = string.sub(selections[1].value, 1, 8)
-  local old = string.sub(selections[2].value, 1, 8)
-  vim.cmd(string.format("DiffviewOpen %s..%s", old, new))
+  local selection1 = string.sub(selections[1].value, 1, 8)
+
+  if #selections == 1 then
+    vim.cmd(string.format("DiffviewOpen %s^!", selection1))
+  else
+    -- Old commit must be the second selection
+    local old = string.sub(selections[2].value, 1, 8)
+    vim.cmd(string.format("DiffviewOpen %s..%s", old, selection1))
+  end
+
   vim.cmd([[stopinsert]])
 end
 

--- a/lua/telescope/_extensions/git_diffs.lua
+++ b/lua/telescope/_extensions/git_diffs.lua
@@ -21,14 +21,19 @@ local function diffview(prompt_bufnr)
   end
 
 
-  local selection1 = string.sub(selections[1].value, 1, 8)
+  -- Sort by date
+  table.sort(selections, function(a, b)
+    return tonumber(vim.fn.systemlist("git show -s --format=%ct " .. a.value)[1]) <
+           tonumber(vim.fn.systemlist("git show -s --format=%ct " .. b.value)[1])
+  end)
+
+  local old = string.sub(selections[1].value, 1, 8)
 
   if #selections == 1 then
-    vim.cmd(string.format("DiffviewOpen %s^!", selection1))
+    vim.cmd(string.format("DiffviewOpen %s^!", old))
   else
-    -- Old commit must be the second selection
-    local old = string.sub(selections[2].value, 1, 8)
-    vim.cmd(string.format("DiffviewOpen %s..%s", old, selection1))
+    local new = string.sub(selections[2].value, 1, 8)
+    vim.cmd(string.format("DiffviewOpen %s..%s", old, new))
   end
 
   vim.cmd([[stopinsert]])

--- a/lua/telescope/_extensions/git_diffs.lua
+++ b/lua/telescope/_extensions/git_diffs.lua
@@ -23,7 +23,7 @@ local function diffview(prompt_bufnr)
 
   local new = string.sub(selections[1].value, 1, 8)
   local old = string.sub(selections[2].value, 1, 8)
-  vim.cmd(string.format("DiffviewOpen -uno %s %s", old, new))
+  vim.cmd(string.format("DiffviewOpen %s..%s", old, new))
   vim.cmd([[stopinsert]])
 end
 


### PR DESCRIPTION
This PR accomplishes the following:

 * Fixed a bug where it was selecting from the first commit that you selected all the way up to the HEAD. I changed the format according to [`:help diffview.txt`](https://github.com/sindrets/diffview.nvim/blob/main/doc/diffview.txt#L66), it appears from some testing that the `-uno` flag is for passing in one commit to do just what I had described.
 * If the user only selects one commit, pulls up the diff for that commit from the previous one. If there is no selection, it picks the currently highlighted commit.
 * A 2-commit selection will always be ordered by date. This is useful when using the fuzzy finder to make your picks, reading chronologically from the top-down.